### PR TITLE
Fix cross-browser speech recognition

### DIFF
--- a/static/recorder.js
+++ b/static/recorder.js
@@ -1,4 +1,9 @@
-const recognition = new webkitSpeechRecognition()
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+if (!SpeechRecognition) {
+  alert('Speech recognition is not supported in this browser.')
+  throw new Error('Speech recognition not supported')
+}
+const recognition = new SpeechRecognition()
 recognition.lang = 'en-US'
 recognition.interimResults = false
 recognition.continuous = true


### PR DESCRIPTION
## Summary
- ensure `recorder.js` works on browsers that don't expose `webkitSpeechRecognition`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6857adf184f4832ebf1ee11ce68ed0d0